### PR TITLE
Automatically Build Project

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,13 @@
         <!-- Test Dependencies -->
         <junit.version>4.12</junit.version>
     </properties>
+    
+    <repositories>
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
+        </repository>
+    </repositories>
 
     <dependencies>
         <!-- data-binding; ObjectMapper, JsonNode and related classes are here -->

--- a/pom.xml
+++ b/pom.xml
@@ -31,8 +31,8 @@
 
         <!-- Http client -->
         <dependency>
-            <groupId>com.mb3364.http</groupId>
-            <artifactId>async-http-client</artifactId>
+            <groupId>com.github.urgrue</groupId>
+            <artifactId>java-async-http</artifactId>
             <version>${async-http-client.version}</version>
         </dependency>
 


### PR DESCRIPTION
Hi!

I really like your library; I think it's great that something like this exists, however it's not terribly easy to include in a personal project because it doesn't appear to be anywhere on Maven and wasn't immediately compatible with [jitpack.io](http://jitpack.io) because of its dependency on one of your other projects.

It turns out that this is really easy to fix though, because you use Maven in your projects (P.s. thanks for that, you're awesome!). If you add the Jitpack service as a dependency, you can directly get the async-http-client jar from your Github instead of users having to download it themselves.

This makes it so that instead of manually downloading all of your project dependencies, anyone interested in your project can include it via Maven dependency, because jitpack.io will package it in a jar. Overall, this makes it easier to use your code because I don't have to manage the jars manually, and can rely on the regular Maven process.

This pull request contains the minimum changes to make this magic happen, which is really just like 6 lines of code changed in your pom.xml, if you just want to accept the PR. If you don't want to do that, that's fine too, just reject the pull request. But support for all of your dependencies being right there would be very helpful <3
